### PR TITLE
Single Authentication Guard

### DIFF
--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -2,7 +2,6 @@
 
 namespace Canvas\Http\Controllers\Auth;
 
-use Auth;
 use Session;
 use Validator;
 use Canvas\Models\User;
@@ -99,7 +98,6 @@ class LoginController extends Controller
             'password' => bcrypt($data['password']),
         ]);
     }
-
 
     /**
      * During the login process, call the GitHub API and grab the latest

--- a/src/Http/Controllers/Auth/LoginController.php
+++ b/src/Http/Controllers/Auth/LoginController.php
@@ -100,15 +100,6 @@ class LoginController extends Controller
         ]);
     }
 
-    /**
-     * Get the guard to be used.
-     *
-     * @return \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected function guard()
-    {
-        return Auth::guard('canvas');
-    }
 
     /**
      * During the login process, call the GitHub API and grab the latest

--- a/src/Http/Controllers/Auth/PasswordController.php
+++ b/src/Http/Controllers/Auth/PasswordController.php
@@ -2,7 +2,6 @@
 
 namespace Canvas\Http\Controllers\Auth;
 
-use Auth;
 use Session;
 use Illuminate\Http\Request;
 use Canvas\Http\Controllers\Controller;
@@ -35,7 +34,7 @@ class PasswordController extends Controller
             'new_password' => 'required|confirmed|min:6',
         ]);
 
-        $guard = Auth::guard('canvas');
+        $guard = $this->guard();
 
         if (! $guard->validate($request->only('password'))) {
             return back()->withErrors(trans('auth.failed'));

--- a/src/Http/Controllers/Auth/RegisterController.php
+++ b/src/Http/Controllers/Auth/RegisterController.php
@@ -2,7 +2,6 @@
 
 namespace Canvas\Http\Controllers\Auth;
 
-use Auth;
 use Validator;
 use Canvas\Models\User;
 use Canvas\Helpers\CanvasHelper;

--- a/src/Http/Controllers/Auth/RegisterController.php
+++ b/src/Http/Controllers/Auth/RegisterController.php
@@ -71,13 +71,4 @@ class RegisterController extends Controller
         ]);
     }
 
-    /**
-     * Get the guard to be used.
-     *
-     * @return \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected function guard()
-    {
-        return Auth::guard('canvas');
-    }
 }

--- a/src/Http/Controllers/Auth/RegisterController.php
+++ b/src/Http/Controllers/Auth/RegisterController.php
@@ -69,5 +69,4 @@ class RegisterController extends Controller
             'password' => bcrypt($data['password']),
         ]);
     }
-
 }

--- a/src/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/Auth/ResetPasswordController.php
@@ -2,7 +2,6 @@
 
 namespace Canvas\Http\Controllers\Auth;
 
-use Auth;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Password;

--- a/src/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/Auth/ResetPasswordController.php
@@ -62,5 +62,4 @@ class ResetPasswordController extends Controller
     {
         return Password::broker('canvas_users');
     }
-
 }

--- a/src/Http/Controllers/Auth/ResetPasswordController.php
+++ b/src/Http/Controllers/Auth/ResetPasswordController.php
@@ -64,13 +64,4 @@ class ResetPasswordController extends Controller
         return Password::broker('canvas_users');
     }
 
-    /**
-     * Get the guard to be used during password reset.
-     *
-     * @return \Illuminate\Contracts\Auth\StatefulGuard
-     */
-    protected function guard()
-    {
-        return Auth::guard('canvas');
-    }
 }

--- a/src/Http/Controllers/Backend/ProfileController.php
+++ b/src/Http/Controllers/Backend/ProfileController.php
@@ -17,7 +17,7 @@ class ProfileController extends Controller
      */
     public function index()
     {
-        $userData = Auth::user()->toArray();
+        $userData = $this->gaurd()->user()->toArray();
         $blogData = config('blog');
         $data = array_merge($userData, $blogData);
 
@@ -32,7 +32,7 @@ class ProfileController extends Controller
     public function editPrivacy()
     {
         return view('canvas::backend.profile.privacy', [
-            'data' => array_merge(Auth::user()->toArray(), config('blog')),
+            'data' => array_merge($this->gaurd()->user()->toArray(), config('blog')),
         ]);
     }
 

--- a/src/Http/Controllers/Backend/ProfileController.php
+++ b/src/Http/Controllers/Backend/ProfileController.php
@@ -2,7 +2,6 @@
 
 namespace Canvas\Http\Controllers\Backend;
 
-use Auth;
 use Session;
 use Canvas\Models\User;
 use Canvas\Http\Controllers\Controller;
@@ -17,7 +16,7 @@ class ProfileController extends Controller
      */
     public function index()
     {
-        $userData = $this->gaurd()->user()->toArray();
+        $userData = $this->guard()->user()->toArray();
         $blogData = config('blog');
         $data = array_merge($userData, $blogData);
 
@@ -32,7 +31,7 @@ class ProfileController extends Controller
     public function editPrivacy()
     {
         return view('canvas::backend.profile.privacy', [
-            'data' => array_merge($this->gaurd()->user()->toArray(), config('blog')),
+            'data' => array_merge($this->guard()->user()->toArray(), config('blog')),
         ]);
     }
 

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -2,6 +2,7 @@
 
 namespace Canvas\Http\Controllers;
 
+use Auth;
 use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -10,4 +10,14 @@ use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 abstract class Controller extends BaseController
 {
     use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+
+    /**
+     * Get the guard to be used.
+     *
+     * @return \Illuminate\Contracts\Auth\StatefulGuard
+     */
+    protected function guard()
+    {
+        return Auth::guard('canvas');
+    }
 }


### PR DESCRIPTION
When using multiple authentication guards with multiple providers. 

The following error occurred when trying to render view for url "admin/profile"

```
ErrorException in c1b0dac7209e3569b83cacf4b792e5f635791a7b.php line 5:
Undefined index: bio (View: /projects/blog/vendor/cnvs/easel/resources/views/backend/profile/partials/form/summary.blade.php) (View: /projects/blog/vendor/cnvs/easel/resources/views/backend/profile/partials/form/summary.blade.php)
```

The exception was generated because [Line 20](https://github.com/cnvs/easel/blob/master/src/Http/Controllers/Backend/ProfileController.php#L20) and [Line 35](https://github.com/cnvs/easel/blob/master/src/Http/Controllers/Backend/ProfileController.php#L35)

converted the User object returned from the default authentication guard using
```Auth::user()``` instead of ```Auth::guard('canvas')->user()``` which did not have attributes from ```Canvas\Models\User``` . 

The pull request provides a ```guard()``` method in the base controller which is then utilized consistently throughout all child controllers. It also removes similar occurrences in the ```Auth\LoginController``` to avoid duplication of concerns.