### PR TITLE
Need to change for PostgreSQL "Not null violation" Exception

### DIFF
--- a/src/Console/Commands/CanvasCommand.php
+++ b/src/Console/Commands/CanvasCommand.php
@@ -163,7 +163,7 @@ class CanvasCommand extends Command
 
     protected function createUser($email, $password, $firstName, $lastName)
     {
-        $user = User::firstOrCreate(['email' => $email]);
+        $user = User::firstOrNew(['email' => $email]);
         $user->password = bcrypt($password);
         $user->first_name = $firstName;
         $user->last_name = $lastName;


### PR DESCRIPTION
firstOrCreate method trying to create new row on table, which fails on PostgreSQL, need to updated as firstOrNew which returns Model instance, which we need.

More info : https://laravel.com/docs/5.4/eloquent#inserting-and-updating-models / Other Creation Methods.