### PR TITLE
Moved the default post_layout location to the config file

### DIFF
--- a/config/blog.php
+++ b/config/blog.php
@@ -34,11 +34,10 @@ return [
     | Canvas Configuration : Post Layout
     |--------------------------------------------------------------------------
     |
-    | The post layout is only specified in src\Jobs\PostFormFields.php.
-    | If you need to update the layout, just change it there.
+    | The default layout for creating new posts.
     |
     */
-    'post_layout' => Canvas\Jobs\PostFormFields::$blogLayout,
+    'post_layout' => 'canvas::frontend.blog.post',
 
     /*
     |--------------------------------------------------------------------------

--- a/src/Jobs/PostFormFields.php
+++ b/src/Jobs/PostFormFields.php
@@ -22,13 +22,6 @@ class PostFormFields
     protected $id;
 
     /**
-     * The default layout for creating new posts.
-     *
-     * @var string
-     */
-    public static $blogLayout = 'canvas::frontend.blog.post';
-
-    /**
      * List of fields and default value for each field.
      *
      * @var array
@@ -58,7 +51,7 @@ class PostFormFields
     public function __construct($id = null)
     {
         $this->id = $id;
-        $this->fieldList['layout'] = self::$blogLayout;
+        $this->fieldList['layout'] = config('blog.post_layout');
     }
 
     /**


### PR DESCRIPTION
I think moving the declaration of the default `post_layout` from the Job to the config file makes more sense, and makes it easier to modify