### PR TITLE
add 'v-pre' directive in post's textarea

### DIFF
--- a/resources/views/backend/post/partials/form.blade.php
+++ b/resources/views/backend/post/partials/form.blade.php
@@ -55,7 +55,7 @@
                     <br>
                     <div class="form-group">
                         <div class="fg-line">
-                            <textarea id="editor" name="content" placeholder="Content">{{ $content }}</textarea>
+                            <textarea id="editor" name="content" placeholder="Content" v-pre>{{ $content }}</textarea>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
When some code with "{{ some_code }}" is in the textarea, the form gets blank, this is happening because Vue is trying read the code inside the textarea, Vue's v-pre directive avoids this behavior.

Im doing the PR in develop branch, is this correct?