### PR TITLE
Use $post-subtitle instead of $post->meta_description

### DIFF
--- a/resources/views/frontend/blog/post.blade.php
+++ b/resources/views/frontend/blog/post.blade.php
@@ -2,8 +2,8 @@
 
 @section('og-title', $post->title)
 @section('twitter-title', $post->title)
-@section('og-description', $post->meta_description)
-@section('twitter-description', $post->meta_description)
+@section('og-description', $post->subtitle)
+@section('twitter-description', $post->subtitle)
 @section('title', \Canvas\Models\Settings::blogTitle().' | '.$post->title)
 @if ($post->page_image)
     @section('og-image', url( $post->page_image ))


### PR DESCRIPTION
Attempt to fix the post description issue [#339](https://github.com/cnvs/canvas/issues/339) listed at [cnvs/canvas](https://github.com/cnvs/canvas/).