### PR TITLE
handle old link of a post so it doesnt return 404

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,8 @@ Route::group([
             Route::get('post/{slug}', 'Canvas\Http\Controllers\Frontend\BlogController@showPost')->name('canvas.blog.post.show');
         });
 
+        Route::get('/blog/{slug}', 'Canvas\Http\Controllers\Frontend\BlogController@handleOldLink')->name('canvas.blog.post.handle_old_link');
+
         /* Authentication routes. */
         Route::group([
             'namespace' => 'Canvas\Http\Controllers\Auth',

--- a/src/Http/Controllers/Frontend/BlogController.php
+++ b/src/Http/Controllers/Frontend/BlogController.php
@@ -67,8 +67,6 @@ class BlogController extends Controller
      */
     public function handleOldLink($slug)
     {
-        $prefix = \Canvas\Helpers\RouteHelper::getBlogPrefix();
-
-        return redirect()->to("/{$prefix}/post/{$slug}", 301);
+        return redirect()->route('canvas.blog.post.show', ['slug' => $slug], 301);
     }
 }

--- a/src/Http/Controllers/Frontend/BlogController.php
+++ b/src/Http/Controllers/Frontend/BlogController.php
@@ -58,4 +58,16 @@ class BlogController extends Controller
 
         return view($post->layout, compact('post', 'tag', 'slug', 'title', 'user', 'css', 'js', 'socialHeaderIconsUser'));
     }
+
+    /**
+     * Permanent redirect from old link to the new one
+     *
+     * @param $slug
+     * @return \Illuminate\Http\Response
+    */
+    public function handleOldLink($slug)
+    {
+        $prefix = \Canvas\Helpers\RouteHelper::getBlogPrefix();
+        return redirect()->to("/{$prefix}/post/{$slug}", 301);
+    }
 }

--- a/src/Http/Controllers/Frontend/BlogController.php
+++ b/src/Http/Controllers/Frontend/BlogController.php
@@ -60,14 +60,15 @@ class BlogController extends Controller
     }
 
     /**
-     * Permanent redirect from old link to the new one
+     * Permanent redirect from old link to the new one.
      *
      * @param $slug
      * @return \Illuminate\Http\Response
-    */
+     */
     public function handleOldLink($slug)
     {
         $prefix = \Canvas\Helpers\RouteHelper::getBlogPrefix();
+
         return redirect()->to("/{$prefix}/post/{$slug}", 301);
     }
 }


### PR DESCRIPTION
I just noticed that the link of posts are changed.

From /blog/{slug} to -> /blog/post/{slug}

It caused some of my articles that already indexed on google and mentioned in several people's blog return 404. So I created this pull request to handle the traffics from old link, and redirect it permanently to the new one.
