### PR TITLE
Remove the mix helper whilst we work on versioning   

### DIFF
--- a/mix-manifest.json
+++ b/mix-manifest.json
@@ -1,8 +1,0 @@
-{
-    "/public/assets/css/frontend.css": "/public/assets/css/frontend.css",
-    "/public/assets/css/backend.css": "/public/assets/css/backend.css",
-    "/public/assets/css/media-manager.css": "/public/assets/css/media-manager.css",
-    "/public/assets/js/frontend.js": "/public/assets/js/frontend.js",
-    "/public/assets/js/vendor.js": "/public/assets/js/vendor.js",
-    "/public/assets/js/app.js": "/public/assets/js/app.js"
-}

--- a/resources/views/backend/shared/partials/css.blade.php
+++ b/resources/views/backend/shared/partials/css.blade.php
@@ -1,2 +1,2 @@
-<link rel="stylesheet" type="text/css" href="{{ mix('vendor/canvas/assets/css/backend.css') }}">
-<link rel="stylesheet" type="text/css" href="{{ mix('vendor/canvas/assets/css/media-manager.css') }}">
+<link rel="stylesheet" type="text/css" href="{{ asset('vendor/canvas/assets/css/backend.css') }}">
+<link rel="stylesheet" type="text/css" href="{{ asset('vendor/canvas/assets/css/media-manager.css') }}">

--- a/resources/views/backend/shared/partials/js.blade.php
+++ b/resources/views/backend/shared/partials/js.blade.php
@@ -1,5 +1,5 @@
-<script type="text/javascript" src="{{ mix('vendor/canvas/assets/js/vendor.js') }}"></script>
-<script type="text/javascript" src="{{ mix('vendor/canvas/assets/js/app.js') }}"></script>
+<script type="text/javascript" src="{{ asset('vendor/canvas/assets/js/vendor.js') }}"></script>
+<script type="text/javascript" src="{{ asset('vendor/canvas/assets/js/app.js') }}"></script>
 <script type="text/javascript">
     window.Laravel = <?php echo json_encode([
             'csrfToken' => csrf_token(),

--- a/resources/views/frontend/blog/index.blade.php
+++ b/resources/views/frontend/blog/index.blade.php
@@ -23,5 +23,5 @@
 @stop
 
 @section('unique-js')
-    <script src="{{ mix('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
+    <script src="{{ asset('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
 @endsection

--- a/resources/views/frontend/blog/post.blade.php
+++ b/resources/views/frontend/blog/post.blade.php
@@ -44,5 +44,5 @@
 @stop
 
 @section('unique-js')
-    <script src="{{ mix('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
+    <script src="{{ asset('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
 @endsection

--- a/resources/views/frontend/shared/partials/css.blade.php
+++ b/resources/views/frontend/shared/partials/css.blade.php
@@ -2,4 +2,4 @@
 <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/themes/prism.min.css">
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/prism.min.js"></script>
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.5.1/components/prism-php.min.js"></script>
-<link rel="stylesheet" type="text/css" href="{{ mix('vendor/canvas/assets/css/frontend.css') }}">
+<link rel="stylesheet" type="text/css" href="{{ asset('vendor/canvas/assets/css/frontend.css') }}">


### PR DESCRIPTION
Replace the mix helper with the asset helper - tested in a canvas repo and the ui is now being rendered as expected