### PR TITLE
Settings Model and Controller Improvements

### DIFF
--- a/src/Http/Controllers/Backend/SettingsController.php
+++ b/src/Http/Controllers/Backend/SettingsController.php
@@ -87,31 +87,61 @@ class SettingsController extends Controller
      */
     public function store(SettingsUpdateRequest $request)
     {
-        Settings::updateOrCreate(['setting_name' => 'blog_title'], ['setting_value' => $request->toArray()['blog_title']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_subtitle'], ['setting_value' => $request->toArray()['blog_subtitle']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_description'], ['setting_value' => $request->toArray()['blog_description']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_seo'], ['setting_value' => $request->toArray()['blog_seo']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_author'], ['setting_value' => $request->toArray()['blog_author']]);
-        Settings::updateOrCreate(['setting_name' => 'ga_id'], ['setting_value' => $request->toArray()['ga_id']]);
-        Settings::updateOrCreate(['setting_name' => 'twitter_card_type'], ['setting_value' => $request->toArray()['twitter_card_type']]);
-        Settings::updateOrCreate(['setting_name' => 'custom_css'], ['setting_value' => $request->toArray()['custom_css']]);
-        Settings::updateOrCreate(['setting_name' => 'custom_js'], ['setting_value' => $request->toArray()['custom_js']]);
-        Settings::updateOrCreate(['setting_name' => 'social_header_icons_user_id'], ['setting_value' => $request->toArray()['social_header_icons_user_id']]);
+        $settings = [
+            'blog_title',
+            'blog_subtitle',
+            'blog_description',
+            'blog_seo',
+            'blog_author',
+            'ga_id',
+            'twitter_card_type',
+            'custom_css',
+            'custom_js',
+            'social_header_icons_user_id',
+        ];
 
-        if (isset($request->toArray()['disqus_name'])) {
-            Settings::updateOrCreate(['setting_name' => 'disqus_name'], ['setting_value' => $request->toArray()['disqus_name']]);
+        foreach ($settings as $name) {
+            $this->saveSettingFromRequest($request, $name);
         }
 
-        if (isset($request->toArray()['changyan_appid']) || isset($request->toArray()['changyan_conf'])) {
-            Settings::updateOrCreate(['setting_name' => 'changyan_appid'], ['setting_value' => $request->toArray()['changyan_appid']]);
-            Settings::updateOrCreate(['setting_name' => 'changyan_conf'], ['setting_value' => $request->toArray()['changyan_conf']]);
+        if ($request->exists('disqus_name')) {
+            $this->saveSettingFromRequest($request, 'disqus_name');
+        }
+
+        if ($request->exists('changyan_appid') || $request->exists('changyan_conf')) {
+            $this->saveSettingFromRequest($request, 'changyan_appid');
+            $this->saveSettingFromRequest($request, 'changyan_conf');
         }
 
         Session::put('_update-settings', trans('canvas::messages.save_settings_success'));
 
         // Update the theme
-        $this->themeManager->setActiveTheme($request->toArray()['theme']);
+        $this->themeManager->setActiveTheme($request->input('theme'));
 
         return redirect()->route('canvas.admin.settings');
+    }
+
+    /**
+     * Creates or updates a given setting.
+     *
+     * @param  string $name  Setting name
+     * @param  string $value Setting value
+     * @return void
+     */
+    protected function saveSetting($name, $value)
+    {
+        Settings::updateOrCreate(['setting_name' => $name], ['setting_value' => $value]);
+    }
+
+    /**
+     * Creates or updates a given setting, based in data from the request.
+     *
+     * @param  SettingsUpdateRequest $request Request object
+     * @param  string                $name    Setting name
+     * @return void
+     */
+    protected function saveSettingFromRequest(SettingsUpdateRequest $request, $name)
+    {
+        $this->saveSetting($name, $request->input($name));
     }
 }

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -36,7 +36,7 @@ class Settings extends Model
      */
     public static function blogTitle()
     {
-        return self::getByName('blog_title');
+        return static::getByName('blog_title');
     }
 
     /**
@@ -46,7 +46,7 @@ class Settings extends Model
      */
     public static function blogSubTitle()
     {
-        return self::getByName('blog_subtitle');
+        return static::getByName('blog_subtitle');
     }
 
     /**
@@ -56,7 +56,7 @@ class Settings extends Model
      */
     public static function blogDescription()
     {
-        return self::getByName('blog_description');
+        return static::getByName('blog_description');
     }
 
     /**
@@ -66,7 +66,7 @@ class Settings extends Model
      */
     public static function blogSeo()
     {
-        return self::getByName('blog_seo');
+        return static::getByName('blog_seo');
     }
 
     /**
@@ -76,7 +76,7 @@ class Settings extends Model
      */
     public static function blogAuthor()
     {
-        return self::getByName('blog_author');
+        return static::getByName('blog_author');
     }
 
     /**
@@ -86,7 +86,7 @@ class Settings extends Model
      */
     public static function canvasVersion()
     {
-        return self::getByName('canvas_version');
+        return static::getByName('canvas_version');
     }
 
     /**
@@ -104,7 +104,7 @@ class Settings extends Model
         if (! Schema::hasTable(CanvasHelper::TABLES['settings'])) {
             return false;
         } else {
-            return self::getByName('installed');
+            return static::getByName('installed');
         }
     }
 
@@ -115,7 +115,7 @@ class Settings extends Model
      */
     public static function latestRelease()
     {
-        return self::getByName('latest_release');
+        return static::getByName('latest_release');
     }
 
     /**
@@ -125,7 +125,7 @@ class Settings extends Model
      */
     public static function disqus()
     {
-        return self::getByName('disqus_name');
+        return static::getByName('disqus_name');
     }
 
     /**
@@ -135,7 +135,7 @@ class Settings extends Model
      */
     public static function changyanAppId()
     {
-        return self::getByName('changyan_appid');
+        return static::getByName('changyan_appid');
     }
 
     /**
@@ -145,7 +145,7 @@ class Settings extends Model
      */
     public static function changyanConf()
     {
-        return self::getByName('changyan_conf');
+        return static::getByName('changyan_conf');
     }
 
     /**
@@ -155,18 +155,25 @@ class Settings extends Model
      */
     public static function gaId()
     {
-        return self::getByName('ga_id');
+        return static::getByName('ga_id');
     }
 
     /**
      * Get the value settings by name.
      *
-     * @param string $settingName
+     * @param  string $settingName Name of setting
+     * @param  string $fallback Fallback if the setting does not exist
      * @return string
      */
-    public static function getByName($settingName)
+    public static function getByName($settingName, $fallback = null)
     {
-        return self::where('setting_name', $settingName)->pluck('setting_value')->first();
+        $setting = static::where('setting_name', $settingName)->first();
+
+        if ($setting === null) {
+            return $fallback;
+        }
+
+        return $setting->setting_value;
     }
 
     /**
@@ -178,7 +185,7 @@ class Settings extends Model
      */
     public static function twitterCardType()
     {
-        return $twitterCardType = self::where('setting_name', 'twitter_card_type')->pluck('setting_value')->first();
+        return static::getByName('twitter_card_type');
     }
 
     /**
@@ -188,7 +195,7 @@ class Settings extends Model
      */
     public static function customCSS()
     {
-        return $customCSS = self::where('setting_name', 'custom_css')->pluck('setting_value')->first();
+        return static::getByName('custom_css');
     }
 
     /**
@@ -198,7 +205,7 @@ class Settings extends Model
      */
     public static function customJS()
     {
-        return $customJS = self::where('setting_name', 'custom_js')->pluck('setting_value')->first();
+        return static::getByName('custom_js');
     }
 
     /**
@@ -209,6 +216,6 @@ class Settings extends Model
      */
     public static function socialHeaderIconsUserId()
     {
-        return $socialHeaderIconsUserId = self::where('setting_name', 'social_header_icons_user_id')->pluck('setting_value')->first();
+        return static::getByName('social_header_icons_user_id');
     }
 }


### PR DESCRIPTION
This PR accomplishes 4 things. Two of which are stylistic / minor, and two are to allow for added features which will be presented in a separate PR.

- [x] Change references from `self` to `static` in `Settings` model to allow for local improvements (`self` will be more restrictive than `static`, as I have found when making local improvements)
- [x] Remove redundancy and increase readability in `SettingsController` (move data into an array so it can be looped, and split out logic in to two helper methods)
- [x] Change `Settings::getByName` to accept a fallback in the case that the setting doesn't yet exist (useful for when an upgrade is pulled in, and a default value needs to be set, just in case the user/admin is not aware)
- [x] Include two new helper methods `SettingsController` to make it easier to create or update Setting rows (precursor for another PR which I will be making shortly...)

Some of these changes may seem pointless or abstract, but I will present a use case in my next PR -- which would depend on the results of this PR. I am creating a new Setting entry locally which needs some core changes to begin with.