### PR TITLE
Allow the default status of a post to be configurable

### DIFF
--- a/resources/views/backend/settings/partials/form/settings.blade.php
+++ b/resources/views/backend/settings/partials/form/settings.blade.php
@@ -54,6 +54,19 @@
 
     <div class="form-group">
         <div class="fg-line">
+            <label class="fg-label">Publish Posts by Default?</label>
+            <select name="post_is_published_default" id="post_is_published_default" class="selectpicker">
+                <option value="1" {{ \Canvas\Helpers\CanvasHelper::selected($data['postIsPublishedDefault']) }}>Yes</option>
+                <option value="0" {{ \Canvas\Helpers\CanvasHelper::selected(!$data['postIsPublishedDefault']) }}>No</option>
+            </select>
+        </div>
+        <small>When this option is checked, new posts will be created with the <code>published</code> status by default, rather than <code>draft</code>.</small>
+    </div>
+
+    <br>
+
+    <div class="form-group">
+        <div class="fg-line">
             <label class="fg-label">Social Header Icons</label>
             <select name="social_header_icons_user_id" id="social_header_icons_user_id" class="selectpicker">
                 @foreach (\Canvas\Models\User::all() as $user)

--- a/resources/views/backend/settings/partials/form/settings.blade.php
+++ b/resources/views/backend/settings/partials/form/settings.blade.php
@@ -54,13 +54,15 @@
 
     <div class="form-group">
         <div class="fg-line">
-            <label class="fg-label">Publish Posts by Default?</label>
-            <select name="post_is_published_default" id="post_is_published_default" class="selectpicker">
-                <option value="1" {{ \Canvas\Helpers\CanvasHelper::selected($data['postIsPublishedDefault']) }}>Yes</option>
-                <option value="0" {{ \Canvas\Helpers\CanvasHelper::selected(!$data['postIsPublishedDefault']) }}>No</option>
-            </select>
+            <label class="ts-label" for="post_is_published_default">Publish Posts by Default?</label>
+            <div>
+                <div class="toggle-switch toggle-switch-demo" data-ts-color="blue">
+                    <input {{ \Canvas\Helpers\CanvasHelper::checked($data['postIsPublishedDefault']) }} type="checkbox" name="post_is_published_default">
+                    <label for="post_is_published_default" class="ts-helper"></label>
+                </div>
+            </div>
+            <small>When this option is checked, new posts will be created with the <code>published</code> status by default, rather than <code>draft</code>.</small>
         </div>
-        <small>When this option is checked, new posts will be created with the <code>published</code> status by default, rather than <code>draft</code>.</small>
     </div>
 
     <br>

--- a/src/Helpers/CanvasHelper.php
+++ b/src/Helpers/CanvasHelper.php
@@ -24,6 +24,17 @@ class CanvasHelper extends Constants
     }
 
     /**
+     * Convenience method to determine if a given select option should be 'selected'.
+     *
+     * @param  boolean $condition If true, return 'checked'
+     * @return string
+     */
+    public static function selected($condition)
+    {
+        return $condition ? 'selected' : '';
+    }
+
+    /**
      * Actions to be taken when user is successfully authenticated.
      *
      * @param Request $request

--- a/src/Helpers/CanvasHelper.php
+++ b/src/Helpers/CanvasHelper.php
@@ -26,7 +26,7 @@ class CanvasHelper extends Constants
     /**
      * Convenience method to determine if a given select option should be 'selected'.
      *
-     * @param  boolean $condition If true, return 'checked'
+     * @param  bool $condition If true, return 'checked'
      * @return string
      */
     public static function selected($condition)

--- a/src/Helpers/CanvasHelper.php
+++ b/src/Helpers/CanvasHelper.php
@@ -24,17 +24,6 @@ class CanvasHelper extends Constants
     }
 
     /**
-     * Convenience method to determine if a given select option should be 'selected'.
-     *
-     * @param  bool $condition If true, return 'checked'
-     * @return string
-     */
-    public static function selected($condition)
-    {
-        return $condition ? 'selected' : '';
-    }
-
-    /**
      * Actions to be taken when user is successfully authenticated.
      *
      * @param Request $request

--- a/src/Http/Controllers/Backend/SettingsController.php
+++ b/src/Http/Controllers/Backend/SettingsController.php
@@ -87,31 +87,61 @@ class SettingsController extends Controller
      */
     public function store(SettingsUpdateRequest $request)
     {
-        Settings::updateOrCreate(['setting_name' => 'blog_title'], ['setting_value' => $request->toArray()['blog_title']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_subtitle'], ['setting_value' => $request->toArray()['blog_subtitle']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_description'], ['setting_value' => $request->toArray()['blog_description']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_seo'], ['setting_value' => $request->toArray()['blog_seo']]);
-        Settings::updateOrCreate(['setting_name' => 'blog_author'], ['setting_value' => $request->toArray()['blog_author']]);
-        Settings::updateOrCreate(['setting_name' => 'ga_id'], ['setting_value' => $request->toArray()['ga_id']]);
-        Settings::updateOrCreate(['setting_name' => 'twitter_card_type'], ['setting_value' => $request->toArray()['twitter_card_type']]);
-        Settings::updateOrCreate(['setting_name' => 'custom_css'], ['setting_value' => $request->toArray()['custom_css']]);
-        Settings::updateOrCreate(['setting_name' => 'custom_js'], ['setting_value' => $request->toArray()['custom_js']]);
-        Settings::updateOrCreate(['setting_name' => 'social_header_icons_user_id'], ['setting_value' => $request->toArray()['social_header_icons_user_id']]);
+        $settings = [
+            'blog_title',
+            'blog_subtitle',
+            'blog_description',
+            'blog_seo',
+            'blog_author',
+            'ga_id',
+            'twitter_card_type',
+            'custom_css',
+            'custom_js',
+            'social_header_icons_user_id',
+        ];
 
-        if (isset($request->toArray()['disqus_name'])) {
-            Settings::updateOrCreate(['setting_name' => 'disqus_name'], ['setting_value' => $request->toArray()['disqus_name']]);
+        foreach ($settings as $name) {
+            $this->saveSettingFromRequest($request, $name);
         }
 
-        if (isset($request->toArray()['changyan_appid']) || isset($request->toArray()['changyan_conf'])) {
-            Settings::updateOrCreate(['setting_name' => 'changyan_appid'], ['setting_value' => $request->toArray()['changyan_appid']]);
-            Settings::updateOrCreate(['setting_name' => 'changyan_conf'], ['setting_value' => $request->toArray()['changyan_conf']]);
+        if ($request->exists('disqus_name')) {
+            $this->saveSettingFromRequest($request, 'disqus_name');
+        }
+
+        if ($request->exists('changyan_appid') || $request->exists('changyan_conf')) {
+            $this->saveSettingFromRequest($request, 'changyan_appid');
+            $this->saveSettingFromRequest($request, 'changyan_conf');
         }
 
         Session::put('_update-settings', trans('canvas::messages.save_settings_success'));
 
         // Update the theme
-        $this->themeManager->setActiveTheme($request->toArray()['theme']);
+        $this->themeManager->setActiveTheme($request->input('theme'));
 
         return redirect()->route('canvas.admin.settings');
+    }
+
+    /**
+     * Creates or updates a given setting.
+     *
+     * @param  string $name  Setting name
+     * @param  string $value Setting value
+     * @return void
+     */
+    protected function saveSetting($name, $value)
+    {
+        Settings::updateOrCreate(['setting_name' => $name], ['setting_value' => $value]);
+    }
+
+    /**
+     * Creates or updates a given setting, based in data from the request.
+     *
+     * @param  SettingsUpdateRequest $request Request object
+     * @param  string                $name    Setting name
+     * @return void
+     */
+    protected function saveSettingFromRequest(SettingsUpdateRequest $request, $name)
+    {
+        $this->saveSetting($name, $request->input($name));
     }
 }

--- a/src/Http/Controllers/Backend/SettingsController.php
+++ b/src/Http/Controllers/Backend/SettingsController.php
@@ -39,6 +39,7 @@ class SettingsController extends Controller
             'blogDescription' => Settings::blogDescription(),
             'blogSeo' => Settings::blogSeo(),
             'blogAuthor' => Settings::blogAuthor(),
+            'postIsPublishedDefault' => Settings::postIsPublishedDefault(),
             'disqus' => Settings::disqus(),
             'changyan_appid' => Settings::changyanAppid(),
             'changyan_conf' => Settings::changyanConf(),
@@ -102,6 +103,13 @@ class SettingsController extends Controller
 
         foreach ($settings as $name) {
             $this->saveSettingFromRequest($request, $name);
+        }
+
+        if ($request->exists('post_is_published_default')) {
+            $this->saveSetting(
+                'post_is_published_default',
+                $request->input('post_is_published_default') === 'yes'
+            );
         }
 
         if ($request->exists('disqus_name')) {

--- a/src/Http/Controllers/Backend/SettingsController.php
+++ b/src/Http/Controllers/Backend/SettingsController.php
@@ -108,7 +108,7 @@ class SettingsController extends Controller
         if ($request->exists('post_is_published_default')) {
             $this->saveSetting(
                 'post_is_published_default',
-                $request->input('post_is_published_default') === 'yes'
+                filter_var($request->input('post_is_published_default'), FILTER_VALIDATE_BOOLEAN)
             );
         }
 

--- a/src/Http/Controllers/Backend/SettingsController.php
+++ b/src/Http/Controllers/Backend/SettingsController.php
@@ -99,17 +99,11 @@ class SettingsController extends Controller
             'custom_css',
             'custom_js',
             'social_header_icons_user_id',
+            'post_is_published_default',
         ];
 
         foreach ($settings as $name) {
             $this->saveSettingFromRequest($request, $name);
-        }
-
-        if ($request->exists('post_is_published_default')) {
-            $this->saveSetting(
-                'post_is_published_default',
-                filter_var($request->input('post_is_published_default'), FILTER_VALIDATE_BOOLEAN)
-            );
         }
 
         if ($request->exists('disqus_name')) {

--- a/src/Http/Requests/SettingsUpdateRequest.php
+++ b/src/Http/Requests/SettingsUpdateRequest.php
@@ -23,9 +23,31 @@ class SettingsUpdateRequest extends FormRequest
      */
     public function rules()
     {
+        $this->sanitiseInput();
+
         return [
             'blog_title' => 'required',
             'blog_subtitle' => 'required',
         ];
+    }
+
+    /**
+     * Sanitise the input from the request.
+     * In this case, the input is type casted where required.
+     *
+     * @return void
+     */
+    public function sanitiseInput()
+    {
+        $source = $this->getInputSource();
+
+        $data = $source->all();
+
+        $data['post_is_published_default'] = filter_var(
+            $this->post_is_published_default,
+            FILTER_VALIDATE_BOOLEAN
+        );
+
+        $source->replace($data);
     }
 }

--- a/src/Jobs/PostFormFields.php
+++ b/src/Jobs/PostFormFields.php
@@ -5,6 +5,7 @@ namespace Canvas\Jobs;
 use Carbon\Carbon;
 use Canvas\Models\Tag;
 use Canvas\Models\Post;
+use Canvas\Models\Settings;
 use Illuminate\Queue\SerializesModels;
 
 /**
@@ -52,6 +53,7 @@ class PostFormFields
     {
         $this->id = $id;
         $this->fieldList['layout'] = config('blog.post_layout');
+        $this->fieldList['is_published'] = Settings::postIsPublishedDefault();
     }
 
     /**

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -82,7 +82,7 @@ class Settings extends Model
     /**
      * Get the 'post is published by default' setting value.
      *
-     * @return @string
+     * @return @bool
      */
     public static function postIsPublishedDefault($fallback = true)
     {

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -36,7 +36,7 @@ class Settings extends Model
      */
     public static function blogTitle()
     {
-        return self::getByName('blog_title');
+        return static::getByName('blog_title');
     }
 
     /**
@@ -46,7 +46,7 @@ class Settings extends Model
      */
     public static function blogSubTitle()
     {
-        return self::getByName('blog_subtitle');
+        return static::getByName('blog_subtitle');
     }
 
     /**
@@ -56,7 +56,7 @@ class Settings extends Model
      */
     public static function blogDescription()
     {
-        return self::getByName('blog_description');
+        return static::getByName('blog_description');
     }
 
     /**
@@ -66,7 +66,7 @@ class Settings extends Model
      */
     public static function blogSeo()
     {
-        return self::getByName('blog_seo');
+        return static::getByName('blog_seo');
     }
 
     /**
@@ -76,7 +76,7 @@ class Settings extends Model
      */
     public static function blogAuthor()
     {
-        return self::getByName('blog_author');
+        return static::getByName('blog_author');
     }
 
     /**
@@ -86,7 +86,7 @@ class Settings extends Model
      */
     public static function canvasVersion()
     {
-        return self::getByName('canvas_version');
+        return static::getByName('canvas_version');
     }
 
     /**
@@ -104,7 +104,7 @@ class Settings extends Model
         if (! Schema::hasTable(CanvasHelper::TABLES['settings'])) {
             return false;
         } else {
-            return self::getByName('installed');
+            return static::getByName('installed');
         }
     }
 
@@ -115,7 +115,7 @@ class Settings extends Model
      */
     public static function latestRelease()
     {
-        return self::getByName('latest_release');
+        return static::getByName('latest_release');
     }
 
     /**
@@ -125,7 +125,7 @@ class Settings extends Model
      */
     public static function disqus()
     {
-        return self::getByName('disqus_name');
+        return static::getByName('disqus_name');
     }
 
     /**
@@ -135,7 +135,7 @@ class Settings extends Model
      */
     public static function changyanAppId()
     {
-        return self::getByName('changyan_appid');
+        return static::getByName('changyan_appid');
     }
 
     /**
@@ -145,7 +145,7 @@ class Settings extends Model
      */
     public static function changyanConf()
     {
-        return self::getByName('changyan_conf');
+        return static::getByName('changyan_conf');
     }
 
     /**
@@ -155,18 +155,25 @@ class Settings extends Model
      */
     public static function gaId()
     {
-        return self::getByName('ga_id');
+        return static::getByName('ga_id');
     }
 
     /**
      * Get the value settings by name.
      *
-     * @param string $settingName
+     * @param  string $settingName Name of setting
+     * @param  string $fallback Fallback if the setting does not exist
      * @return string
      */
-    public static function getByName($settingName)
+    public static function getByName($settingName, $fallback = null)
     {
-        return self::where('setting_name', $settingName)->pluck('setting_value')->first();
+        $setting = static::where('setting_name', $settingName)->first();
+
+        if ($setting === null) {
+            return $fallback;
+        }
+
+        return $setting->setting_value;
     }
 
     /**
@@ -178,7 +185,7 @@ class Settings extends Model
      */
     public static function twitterCardType()
     {
-        return $twitterCardType = self::where('setting_name', 'twitter_card_type')->pluck('setting_value')->first();
+        return static::getByName('twitter_card_type');
     }
 
     /**
@@ -188,7 +195,7 @@ class Settings extends Model
      */
     public static function customCSS()
     {
-        return $customCSS = self::where('setting_name', 'custom_css')->pluck('setting_value')->first();
+        return static::getByName('custom_css');
     }
 
     /**
@@ -198,7 +205,7 @@ class Settings extends Model
      */
     public static function customJS()
     {
-        return $customJS = self::where('setting_name', 'custom_js')->pluck('setting_value')->first();
+        return static::getByName('custom_js');
     }
 
     /**
@@ -209,6 +216,6 @@ class Settings extends Model
      */
     public static function socialHeaderIconsUserId()
     {
-        return $socialHeaderIconsUserId = self::where('setting_name', 'social_header_icons_user_id')->pluck('setting_value')->first();
+        return static::getByName('social_header_icons_user_id');
     }
 }

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -80,6 +80,16 @@ class Settings extends Model
     }
 
     /**
+     * Get the 'post is published by default' setting value.
+     *
+     * @return @string
+     */
+    public static function postIsPublishedDefault($fallback = true)
+    {
+        return static::getByName('post_is_published_default', true);
+    }
+
+    /**
      * Get the current Canvas application version.
      *
      * return @string


### PR DESCRIPTION
The purpose of this PR is to allow for blog owners to decide if the default status of a post should be published or not. This is particularly handy if you have non-experienced users working on your blog, and you would want to prevent accidental publishing, etc.

~~The PR is branched from _another_ PR which I created (#154) which lays the foundations for some of the features in this PR.~~ - now merged.

Essentially, this PR creates a new `Setting` row, and updates the new post form to reflect this setting.

Due to the changes in #154, if this PR is merged, the _default_ value will be *true* -- so that it will require a blog owner to manually decide if they want to change their site's behaviour. I think by default a post should be _not_ published, but that's a bigger discussion...

~~The diff in this PR may look strange as it is including changes from the other PR, so hopefully that PR is reviewed first.~~

The next step will be to resolve the Settings model from the container, so that I can override it locally, and Easel will use my locally overridden copy. That will be saved for a separate PR as it's probably a bit more work...

## Todo
- [x] Update Setting option to use a checkbox rather than dropdown.