### PR TITLE
Adding structured data snippets to the blog

### DIFF
--- a/resources/views/frontend/blog/index.blade.php
+++ b/resources/views/frontend/blog/index.blade.php
@@ -26,6 +26,6 @@
     <script src="{{ asset('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
 @endsection
 
-@section('structured-data-js')
+@push('structured-data-js')
     @include('canvas::frontend.blog.partials.blog-structured-data')
-@endsection
+@endpush

--- a/resources/views/frontend/blog/index.blade.php
+++ b/resources/views/frontend/blog/index.blade.php
@@ -25,3 +25,7 @@
 @section('unique-js')
     <script src="{{ asset('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
 @endsection
+
+@section('structured-data-js')
+    @include('canvas::frontend.blog.partials.blog-structured-data')
+@endsection

--- a/resources/views/frontend/blog/partials/blog-structured-data.blade.php
+++ b/resources/views/frontend/blog/partials/blog-structured-data.blade.php
@@ -1,0 +1,16 @@
+<script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": "Blog",
+        "accessMode": ["textual", "visual"],
+        "accountablePerson": {
+            "@type": "Person",
+            "name": "{{ \Canvas\Models\Settings::blogAuthor() }}"
+        },
+        "alternativeHeadline": "{{ \Canvas\Models\Settings::blogSubtitle() }}",
+        "description": "{{ \Canvas\Models\Settings::blogDescription() }}",
+        "headline": "{{ \Canvas\Models\Settings::blogTitle() }}",
+        "keywords": "{{ \Canvas\Models\Settings::blogSeo() }}",
+        "name": "{{ \Canvas\Models\Settings::blogTitle() }}"
+    }
+</script>

--- a/resources/views/frontend/blog/partials/post-structured-data.blade.php
+++ b/resources/views/frontend/blog/partials/post-structured-data.blade.php
@@ -1,0 +1,66 @@
+<script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": "Article",
+        "accessMode": ["textual", "visual"],
+        "accountablePerson": {
+            "@type": "Person",
+            "name": "{{ $user->first_name .  ' ' . $user->last_name }}",
+            "email": "{{ $user->email }}"
+        },
+        "alternativeHeadline": "{!! $post->subtitle !!}",
+        @if ($post->page_image)
+            "associatedMedia": {
+                "@context": "http://schema.org",
+                "@type": "ImageObject",
+                "contentUrl": "{{ asset($post->page_image) }}",
+                "description": "{{ $post->meta_description }}"
+            },
+            "image": "{{ asset($post->page_image) }}",
+            "thumbnailUrl": "{{ asset($post->page_image) }}",
+        @endif
+        "articleBody": "{{ json_encode($post->content_html, JSON_HEX_QUOT) }}",
+        "author": {
+            "@type": "Person",
+            "name": "{{ $user->first_name .  ' ' . $user->last_name }}",
+            "email": "{{ $user->email }}"
+        },
+        "copyrightHolder": {
+            "@type": "Person",
+            "name": "{{ $user->first_name .  ' ' . $user->last_name }}"
+        },
+        "dateCreated": "{{ \Carbon\Carbon::parse($post->created_at)->toIso8601String() }}",
+        "dateModified": "{{ \Carbon\Carbon::parse($post->updated_at)->toIso8601String() }}",
+        "datePublished": "{{ \Carbon\Carbon::parse($post->published_at)->toIso8601String() }}",
+        "description": "{{ $post->meta_description }}",
+        "headline": "{{ $post->title }}",
+        @php
+            $keywordList = [];
+            foreach ($post->tags as $tag) {
+                $keywordList[] = $tag->tag;
+            }
+        @endphp
+        "keywords": "{{ implode(",",$keywordList) }}",
+        "name": "{{ $post->title }}",
+        "publisher": {
+            "@context" : "http://schema.org",
+            "@type" : "Organization",
+            "name" : "{{ \Canvas\Models\Settings::blogTitle() }}",
+            "url" : "{{ URL::to('/') }}",
+            "logo": {
+                "@context": "http://schema.org",
+                "@type": "ImageObject",
+                "contentUrl": "{{ asset($post->page_image) }}",
+                "description": "{{ \Canvas\Models\Settings::blogSubtitle() }}",
+                "url": "{{ asset($post->page_image) }}"
+            }
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "{{ Request::url() }}"
+        },
+        "text": "{{ json_encode($post->content_html, JSON_HEX_QUOT) }}",
+        "timeRequired": "{{ $post->readingTime() . 'M0S' }}",
+        "wordCount": "{{ str_word_count($post->content_raw) }}"
+    }
+</script>

--- a/resources/views/frontend/blog/partials/posts-structured-data.blade.php
+++ b/resources/views/frontend/blog/partials/posts-structured-data.blade.php
@@ -1,0 +1,66 @@
+<script type="application/ld+json">
+    {
+        "@context": "http://schema.org",
+        "@type": "Article",
+        "accessMode": ["textual", "visual"],
+        "accountablePerson": {
+            "@type": "Person",
+            "name": "{{ $post->user->first_name .  ' ' . $post->user->last_name }}",
+            "email": "{{ $post->user->email }}"
+        },
+        "alternativeHeadline": "{!! $post->subtitle !!}",
+        @if ($post->page_image)
+            "associatedMedia": {
+                "@context": "http://schema.org",
+                "@type": "ImageObject",
+                "contentUrl": "{{ asset($post->page_image) }}",
+                "description": "{{ $post->meta_description }}"
+            },
+            "image": "{{ asset($post->page_image) }}",
+            "thumbnailUrl": "{{ asset($post->page_image) }}",
+        @endif
+        "articleBody": "{{ json_encode($post->content_html, JSON_HEX_QUOT) }}",
+        "author": {
+            "@type": "Person",
+            "name": "{{ $post->user->first_name .  ' ' . $post->user->last_name }}",
+            "email": "{{ $post->user->email }}"
+        },
+        "copyrightHolder": {
+            "@type": "Person",
+            "name": "{{ $post->user->first_name .  ' ' . $post->user->last_name }}"
+        },
+        "dateCreated": "{{ \Carbon\Carbon::parse($post->created_at)->toIso8601String() }}",
+        "dateModified": "{{ \Carbon\Carbon::parse($post->updated_at)->toIso8601String() }}",
+        "datePublished": "{{ \Carbon\Carbon::parse($post->published_at)->toIso8601String() }}",
+        "description": "{{ $post->meta_description }}",
+        "headline": "{{ $post->title }}",
+        @php
+            $keywordList = [];
+            foreach ($post->tags as $tag) {
+                $keywordList[] = $tag->tag;
+            }
+        @endphp
+        "keywords": "{{ implode(",",$keywordList) }}",
+        "name": "{{ $post->title }}",
+        "publisher": {
+            "@context" : "http://schema.org",
+            "@type" : "Organization",
+            "name" : "{{ \Canvas\Models\Settings::blogTitle() }}",
+            "url" : "{{ URL::to('/') }}",
+            "logo": {
+                "@context": "http://schema.org",
+                "@type": "ImageObject",
+                "contentUrl": "{{ asset($post->page_image) }}",
+                "description": "{{ \Canvas\Models\Settings::blogSubtitle() }}",
+                "url": "{{ asset($post->page_image) }}"
+            }
+        },
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "{{ Request::url() }}"
+        },
+        "text": "{{ json_encode($post->content_html, JSON_HEX_QUOT) }}",
+        "timeRequired": "{{ $post->readingTime() . 'M0S' }}",
+        "wordCount": "{{ str_word_count($post->content_raw) }}"
+    }
+</script>

--- a/resources/views/frontend/blog/partials/posts.blade.php
+++ b/resources/views/frontend/blog/partials/posts.blade.php
@@ -17,6 +17,6 @@
     </div>
     <hr>
     @push('structured-data-js')
-        @include('canvas::frontend.blog.partials.post-structured-data')
+        @include('canvas::frontend.blog.partials.posts-structured-data')
     @endpush
 @endforeach

--- a/resources/views/frontend/blog/partials/posts.blade.php
+++ b/resources/views/frontend/blog/partials/posts.blade.php
@@ -16,4 +16,7 @@
         <p style="font-size: 13px"><a href="{{ $post->url($tag) }}">READ MORE...</a></p>
     </div>
     <hr>
+    @section('structured-data-js')
+        @include('canvas::frontend.blog.partials.post-structured-data')
+    @endsection
 @endforeach

--- a/resources/views/frontend/blog/partials/posts.blade.php
+++ b/resources/views/frontend/blog/partials/posts.blade.php
@@ -16,7 +16,7 @@
         <p style="font-size: 13px"><a href="{{ $post->url($tag) }}">READ MORE...</a></p>
     </div>
     <hr>
-    @section('structured-data-js')
+    @push('structured-data-js')
         @include('canvas::frontend.blog.partials.post-structured-data')
-    @endsection
+    @endpush
 @endforeach

--- a/resources/views/frontend/blog/post.blade.php
+++ b/resources/views/frontend/blog/post.blade.php
@@ -47,6 +47,6 @@
     <script src="{{ asset('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
 @endsection
 
-@section('structured-data-js')
+@push('structured-data-js')
     @include('canvas::frontend.blog.partials.post-structured-data')
-@endsection
+@endpush

--- a/resources/views/frontend/blog/post.blade.php
+++ b/resources/views/frontend/blog/post.blade.php
@@ -46,3 +46,7 @@
 @section('unique-js')
     <script src="{{ asset('vendor/canvas/assets/js/frontend.js') }}" charset="utf-8"></script>
 @endsection
+
+@section('structured-data-js')
+    @include('canvas::frontend.blog.partials.post-structured-data')
+@endsection

--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -9,7 +9,7 @@
         @include('canvas::frontend.shared.partials.header')
         @yield('content')
         @yield('unique-js')
-        @yield('structured-data-js')
+        @stack('structured-data-js')
         @include('canvas::frontend.shared.partials.user-generated-js')
         @include('canvas::frontend.shared.partials.footer')
     </body>

--- a/resources/views/frontend/layout.blade.php
+++ b/resources/views/frontend/layout.blade.php
@@ -9,6 +9,7 @@
         @include('canvas::frontend.shared.partials.header')
         @yield('content')
         @yield('unique-js')
+        @yield('structured-data-js')
         @include('canvas::frontend.shared.partials.user-generated-js')
         @include('canvas::frontend.shared.partials.footer')
     </body>


### PR DESCRIPTION
Hi there!

Firstly, thanks for the awesome work on cnvs!

So, this PR is a proposal for new "functionality" on cnvs. I wanted to improve the SEO on my blog, so in the process I ended up implementing [structured data](https://developers.google.com/search/docs/guides/intro-structured-data) on the site. This PR enables the following:

1. Structured Data for the entire Blog as per [the Blog Schema definition](http://schema.org/Blog)
2. Structured Data for the list of posts on the home page (as per[ the Article Schema](http://schema.org/Article)).
3. Structured Data for each individual posts on the post page (as per[ the Article Schema](http://schema.org/Article)).

The implementation is somewhat "minimal" because I guess the requirements may differ from blog to blog, but is just enough to improve SEO.

To give some examples, I have already implemented and integrated this into [my own blog](https://blog.mjshika.xyz/), and using [Google's Structured Data Testing Tool](https://search.google.com/structured-data/testing-tool/u/0/) I am able to get clean valid Structured Data. See example output below (I've only taken snippets from the results and not the entire result, feel free to run the tool against my site to see the complete result).

**Output On Home Page**
<img width="1440" alt="screen shot 2017-10-16 at 6 12 47 pm" src="https://user-images.githubusercontent.com/6643245/31622886-fa99e894-b29d-11e7-80b7-166fd1be6f92.png">


**Output On Post Page**
<img width="1435" alt="screen shot 2017-10-16 at 6 13 22 pm" src="https://user-images.githubusercontent.com/6643245/31622897-005b7810-b29e-11e7-9be8-787439148eb2.png">

And that's about it. I think this would be a nice to have on cnvs? Thoughts?