### PR TITLE
Optimise Canvas Settings model to reduce query count

### DIFF
--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -30,6 +30,46 @@ class Settings extends Model
     public $timestamps = false;
 
     /**
+     * Cached Settings data.
+     * Key = setting name, value = setting value.
+     * @var array
+     */
+    protected static $cachedRows;
+
+    /**
+     * Get the value settings by name.
+     *
+     * @param  string $settingName Name of setting
+     * @param  string $fallback Fallback if the setting does not exist
+     * @return string
+     */
+    public static function getByName($settingName, $fallback = null)
+    {
+        if (static::$cachedRows === null) {
+            static::cache();
+        }
+
+        if ( ! array_key_exists($settingName, static::$cachedRows)) {
+            return $fallback;
+        }
+
+        return static::$cachedRows[$settingName];
+    }
+
+    /**
+     * Cache the Settings values to a simple array.
+     *
+     * @return void
+     */
+    protected static function cache()
+    {
+        static::$cachedRows = static::query()
+            ->pluck('setting_value', 'setting_name')
+            ->toArray()
+        ;
+    }
+
+    /**
      * Get the value of the Blog Title.
      *
      * return @string
@@ -156,24 +196,6 @@ class Settings extends Model
     public static function gaId()
     {
         return static::getByName('ga_id');
-    }
-
-    /**
-     * Get the value settings by name.
-     *
-     * @param  string $settingName Name of setting
-     * @param  string $fallback Fallback if the setting does not exist
-     * @return string
-     */
-    public static function getByName($settingName, $fallback = null)
-    {
-        $setting = static::where('setting_name', $settingName)->first();
-
-        if ($setting === null) {
-            return $fallback;
-        }
-
-        return $setting->setting_value;
     }
 
     /**

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -49,7 +49,7 @@ class Settings extends Model
             static::cache();
         }
 
-        if ( ! array_key_exists($settingName, static::$cachedRows)) {
+        if (! array_key_exists($settingName, static::$cachedRows)) {
             return $fallback;
         }
 
@@ -65,8 +65,7 @@ class Settings extends Model
     {
         static::$cachedRows = static::query()
             ->pluck('setting_value', 'setting_name')
-            ->toArray()
-        ;
+            ->toArray();
     }
 
     /**


### PR DESCRIPTION
Small performance win with this PR. Reduces the duplicate and overall query count. Addresses / fixes issue #157.

Before (on `/blog` URL locally):
21 statements were executed, 7 of which were duplicated, 14 unique

After:
9 statements were executed, 4 of which were duplicated, 5 unique

The cache will only survive one request, and the Settings don't change _during_ a request, so I haven't implemented a forget functionality yet as it's not quite needed.

Next 'duplicate query performance win' resides [here](https://github.com/cnvs/easel/blob/861801e1bde62b6b2bd7b35d6ce53a8927aa037e/resources/views/frontend/blog/partials/paginate-post.blade.php#L32-L34) (line 32 & 34).