### PR TITLE
Fix Settings Model PHPUnit Tests

### DIFF
--- a/database/migrations/2017_10_27_211443_add_unique_to_settings_name_column.php
+++ b/database/migrations/2017_10_27_211443_add_unique_to_settings_name_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddUniqueToSettingsNameColumn extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table(CanvasHelper::TABLES['settings'], function (Blueprint $table) {
+            $table->unique('setting_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table(CanvasHelper::TABLES['settings'], function (Blueprint $table) {
+            $table->dropUnique('setting_name_unique');
+        });
+    }
+}

--- a/database/seeds/SettingsTableSeeder.php
+++ b/database/seeds/SettingsTableSeeder.php
@@ -40,11 +40,6 @@ class SettingsTableSeeder extends Seeder
         $settings->save();
 
         $settings = new Settings();
-        $settings->setting_name = 'blog_title';
-        $settings->setting_value = 'John Doe Blog';
-        $settings->save();
-
-        $settings = new Settings();
         $settings->setting_name = 'ga_id';
         $settings->setting_value = 'johndoe12345';
         $settings->save();

--- a/src/CanvasServiceProvider.php
+++ b/src/CanvasServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Canvas;
 
 use Canvas\Models\Settings;
+use Canvas\Models\Observers\SettingsObserver;
 use Canvas\Helpers\RouteHelper;
 use Canvas\Helpers\SetupHelper;
 use Canvas\Helpers\CanvasHelper;
@@ -151,6 +152,16 @@ class CanvasServiceProvider extends ServiceProvider
     }
 
     /**
+     * Register any Eloquent Model event observers.
+     *
+     * @return void
+     */
+    protected function registerEloquentObservers()
+    {
+        Settings::observe(SettingsObserver::class);
+    }
+
+    /**
      * Bootstrap the application events.
      *
      * @return void
@@ -164,6 +175,7 @@ class CanvasServiceProvider extends ServiceProvider
         $this->handleRoutes();
         $this->handleCommands();
         $this->handleAssets();
+        $this->registerEloquentObservers();
     }
 
     /**

--- a/src/CanvasServiceProvider.php
+++ b/src/CanvasServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Canvas;
 
 use Canvas\Models\Settings;
-use Canvas\Models\Observers\SettingsObserver;
 use Canvas\Helpers\RouteHelper;
 use Canvas\Helpers\SetupHelper;
 use Canvas\Helpers\CanvasHelper;
@@ -24,6 +23,7 @@ use Canvas\Console\Commands\Publish\Assets;
 use Canvas\Console\Commands\Publish\Config;
 use Canvas\Http\Middleware\EnsureInstalled;
 use Maatwebsite\Excel\ExcelServiceProvider;
+use Canvas\Models\Observers\SettingsObserver;
 use Canvas\Http\Middleware\EnsureNotInstalled;
 use Canvas\Console\Commands\Publish\Migrations;
 use Canvas\Extensions\ExtensionsServiceProvider;

--- a/src/Models/Observers/SettingsObserver.php
+++ b/src/Models/Observers/SettingsObserver.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Canvas\Models\Observers;
+
+use Canvas\Models\Settings;
+
+class SettingsObserver
+{
+	/**
+	 * 'saved' event handler for the Settings model.
+	 * Forgets the cache every time a new row is created or updated.
+	 *
+	 * @param  Settings $settings
+	 * @return void
+	 */
+	public function saved(Settings $settings)
+	{
+		Settings::forget();
+	}
+}

--- a/src/Models/Observers/SettingsObserver.php
+++ b/src/Models/Observers/SettingsObserver.php
@@ -6,15 +6,15 @@ use Canvas\Models\Settings;
 
 class SettingsObserver
 {
-	/**
-	 * 'saved' event handler for the Settings model.
-	 * Forgets the cache every time a new row is created or updated.
-	 *
-	 * @param  Settings $settings
-	 * @return void
-	 */
-	public function saved(Settings $settings)
-	{
-		Settings::forget();
-	}
+    /**
+     * 'saved' event handler for the Settings model.
+     * Forgets the cache every time a new row is created or updated.
+     *
+     * @param  Settings $settings
+     * @return void
+     */
+    public function saved(Settings $settings)
+    {
+        Settings::forget();
+    }
 }

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -58,7 +58,7 @@ class Settings extends Model
 
     /**
      * Forget the cached rows.
-     * Handled by SettingsObserver@saved
+     * Handled by SettingsObserver@saved.
      *
      * @return void
      */

--- a/src/Models/Settings.php
+++ b/src/Models/Settings.php
@@ -57,6 +57,17 @@ class Settings extends Model
     }
 
     /**
+     * Forget the cached rows.
+     * Handled by SettingsObserver@saved
+     *
+     * @return void
+     */
+    public static function forget()
+    {
+        static::$cachedRows = null;
+    }
+
+    /**
      * Cache the Settings values to a simple array.
      *
      * @return void


### PR DESCRIPTION
The PHPUnit Tests were failing locally when updating the blog title via the Settings model. Ultimately, this was a combination of:
1. duplicate blog_title rows in the Settings table (Controller updates the first row, and then the last row in the table trumps the cache)
2. Settings model cache was not invalidated on create / update (not important in a real-world scenario, but in the test scenario, the update and fetch operations are called in the same App lifecycle / Request)

This PR uses 3 methods to resolve the two problems mentioned above:
- [x] Remove duplicate 'blog_title' entry in the Settings Seeder
- [x] Add a unique constraint to the `setting_name` column to highlight this style of issue in future
- [x] Add an Eloquent Observer to clear the self-contained Settings Model cache whenever a Settings instance / row is created or updated

The next task is to investigate why Travis did not identify the tests as failing.