### PR TITLE
Laravel 5.4 Upgrade

### DIFF
--- a/src/CanvasServiceProvider.php
+++ b/src/CanvasServiceProvider.php
@@ -196,10 +196,10 @@ class CanvasServiceProvider extends ServiceProvider
         $loader->alias('CanvasSetup', SetupHelper::class);
 
         // Register middleware...
-        $router->middleware('checkIfAdmin', CheckIfAdmin::class);
-        $router->middleware('canvasInstalled', EnsureInstalled::class);
-        $router->middleware('canvasNotInstalled', EnsureNotInstalled::class);
-        $router->middleware('checkForMaintenanceMode', CheckForMaintenanceMode::class);
+        $router->aliasMiddleware('checkIfAdmin', CheckIfAdmin::class);
+        $router->aliasMiddleware('canvasInstalled', EnsureInstalled::class);
+        $router->aliasMiddleware('canvasNotInstalled', EnsureNotInstalled::class);
+        $router->aliasMiddleware('checkForMaintenanceMode', CheckForMaintenanceMode::class);
     }
 
     /**

--- a/src/Helpers/CanvasHelper.php
+++ b/src/Helpers/CanvasHelper.php
@@ -36,7 +36,7 @@ class CanvasHelper extends Constants
         self::getLatestVersion();
 
         // Set login message.
-        Session::set('_login', trans('canvas::messages.login', ['display_name' => $user->display_name]));
+        Session::put('_login', trans('canvas::messages.login', ['display_name' => $user->display_name]));
     }
 
     /**

--- a/src/Http/Controllers/Auth/PasswordController.php
+++ b/src/Http/Controllers/Auth/PasswordController.php
@@ -44,7 +44,7 @@ class PasswordController extends Controller
         $user->password = bcrypt($request->input('new_password'));
         $user->save();
 
-        Session::set('_passwordUpdate', trans('canvas::messages.update_success', ['entity' => 'Your password']));
+        Session::put('_passwordUpdate', trans('canvas::messages.update_success', ['entity' => 'Your password']));
 
         return back();
     }

--- a/src/Http/Controllers/Backend/PostController.php
+++ b/src/Http/Controllers/Backend/PostController.php
@@ -47,7 +47,7 @@ class PostController extends Controller
         $post = Post::create($request->postFillData());
         $post->syncTags($request->get('tags', []));
 
-        Session::set('_new-post', trans('canvas::messages.create_success', ['entity' => 'post']));
+        Session::put('_new-post', trans('canvas::messages.create_success', ['entity' => 'post']));
 
         return redirect()->route('canvas.admin.post.edit', $post->id);
     }
@@ -81,7 +81,7 @@ class PostController extends Controller
         $post->save();
         $post->syncTags($request->get('tags', []));
 
-        Session::set('_update-post', trans('canvas::messages.update_success', ['entity' => 'Post']));
+        Session::put('_update-post', trans('canvas::messages.update_success', ['entity' => 'Post']));
 
         return redirect()->route('canvas.admin.post.edit', $id);
     }
@@ -99,7 +99,7 @@ class PostController extends Controller
         $post->tags()->detach();
         $post->delete();
 
-        Session::set('_delete-post', trans('canvas::messages.delete_success', ['entity' => 'Post']));
+        Session::put('_delete-post', trans('canvas::messages.delete_success', ['entity' => 'Post']));
 
         return redirect()->route('canvas.admin.post.index');
     }

--- a/src/Http/Controllers/Backend/ProfileController.php
+++ b/src/Http/Controllers/Backend/ProfileController.php
@@ -50,7 +50,7 @@ class ProfileController extends Controller
         $user->fill($request->toArray())->save();
         $user->save();
 
-        Session::set('_profile', trans('canvas::messages.update_success', ['entity' => 'Profile']));
+        Session::put('_profile', trans('canvas::messages.update_success', ['entity' => 'Profile']));
 
         return redirect()->route('canvas.admin.profile.index');
     }

--- a/src/Http/Controllers/Backend/SettingsController.php
+++ b/src/Http/Controllers/Backend/SettingsController.php
@@ -107,7 +107,7 @@ class SettingsController extends Controller
             Settings::updateOrCreate(['setting_name' => 'changyan_conf'], ['setting_value' => $request->toArray()['changyan_conf']]);
         }
 
-        Session::set('_update-settings', trans('canvas::messages.save_settings_success'));
+        Session::put('_update-settings', trans('canvas::messages.save_settings_success'));
 
         // Update the theme
         $this->themeManager->setActiveTheme($request->toArray()['theme']);

--- a/src/Http/Controllers/Backend/TagController.php
+++ b/src/Http/Controllers/Backend/TagController.php
@@ -62,7 +62,7 @@ class TagController extends Controller
         $tag->fill($request->toArray())->save();
         $tag->save();
 
-        Session::set('_new-tag', trans('canvas::messages.create_success', ['entity' => 'tag']));
+        Session::put('_new-tag', trans('canvas::messages.create_success', ['entity' => 'tag']));
 
         return redirect()->route('canvas.admin.tag.index');
     }
@@ -99,7 +99,7 @@ class TagController extends Controller
         $tag->fill($request->toArray())->save();
         $tag->save();
 
-        Session::set('_update-tag', trans('canvas::messages.update_success', ['entity' => 'Tag']));
+        Session::put('_update-tag', trans('canvas::messages.update_success', ['entity' => 'Tag']));
 
         return redirect()->route('canvas.admin.tag.edit', $id);
     }
@@ -116,7 +116,7 @@ class TagController extends Controller
         $tag = Tag::findOrFail($id);
         $tag->delete();
 
-        Session::set('_delete-tag', trans('canvas::messages.delete_success', ['entity' => 'Tag']));
+        Session::put('_delete-tag', trans('canvas::messages.delete_success', ['entity' => 'Tag']));
 
         return redirect()->route('canvas.admin.tag.index');
     }

--- a/src/Http/Controllers/Backend/ToolsController.php
+++ b/src/Http/Controllers/Backend/ToolsController.php
@@ -50,9 +50,9 @@ class ToolsController extends Controller
         $exitCode = Artisan::call('route:clear');
         $exitCode = Artisan::call('optimize');
         if ($exitCode === 0) {
-            Session::set('_cache-clear', trans('canvas::messages.cache_clear_success'));
+            Session::put('_cache-clear', trans('canvas::messages.cache_clear_success'));
         } else {
-            Session::set('_cache-clear', trans('canvas::messages.cache_clear_error'));
+            Session::put('_cache-clear', trans('canvas::messages.cache_clear_error'));
         }
 
         return redirect()->route('canvas.admin.tools');
@@ -214,10 +214,10 @@ class ToolsController extends Controller
     {
         $exitCode = Artisan::call('down');
         if ($exitCode === 0) {
-            Session::set('admin_ip', request()->ip());
-            Session::set('_enable-maintenance-mode', trans('canvas::messages.enable_maintenance_mode_success'));
+            Session::put('admin_ip', request()->ip());
+            Session::put('_enable-maintenance-mode', trans('canvas::messages.enable_maintenance_mode_success'));
         } else {
-            Session::set('_enable-maintenance-mode', trans('canvas::messages.enable_maintenance_mode_error'));
+            Session::put('_enable-maintenance-mode', trans('canvas::messages.enable_maintenance_mode_error'));
         }
 
         return redirect()->route('canvas.admin.tools');
@@ -232,9 +232,9 @@ class ToolsController extends Controller
     {
         $exitCode = Artisan::call('up');
         if ($exitCode === 0) {
-            Session::set('_disable-maintenance-mode', trans('canvas::messages.disable_maintenance_mode_success'));
+            Session::put('_disable-maintenance-mode', trans('canvas::messages.disable_maintenance_mode_success'));
         } else {
-            Session::set('_disable-maintenance-mode', trans('canvas::messages.disable_maintenance_mode_error'));
+            Session::put('_disable-maintenance-mode', trans('canvas::messages.disable_maintenance_mode_error'));
         }
 
         return redirect()->route('canvas.admin.tools');

--- a/src/Http/Controllers/Backend/UserController.php
+++ b/src/Http/Controllers/Backend/UserController.php
@@ -49,7 +49,7 @@ class UserController extends Controller
         $user->password = bcrypt($request->password);
         $user->save();
 
-        Session::set('_new-user', trans('canvas::messages.create_success', ['entity' => 'user']));
+        Session::put('_new-user', trans('canvas::messages.create_success', ['entity' => 'user']));
 
         return redirect()->route('canvas.admin.user.index');
     }
@@ -82,7 +82,7 @@ class UserController extends Controller
         $data->fill($request->toArray())->save();
         $data->save();
 
-        Session::set('_updateUser', trans('canvas::messages.update_success', ['entity' => 'User']));
+        Session::put('_updateUser', trans('canvas::messages.update_success', ['entity' => 'User']));
 
         return redirect()->route('canvas.admin.user.edit', compact('data'));
     }
@@ -113,7 +113,7 @@ class UserController extends Controller
     {
         User::where('id', $id)->update(['password' => bcrypt($request->new_password)]);
 
-        Session::set('_updatePassword', trans('canvas::messages.update_success', ['entity' => 'Password']));
+        Session::put('_updatePassword', trans('canvas::messages.update_success', ['entity' => 'Password']));
 
         return redirect()->route('canvas.admin.user.edit', $id);
     }
@@ -137,7 +137,7 @@ class UserController extends Controller
         $user = User::findOrFail($id);
         $user->delete();
 
-        Session::set('_delete-user', trans('canvas::messages.delete_success', ['entity' => 'User']));
+        Session::put('_delete-user', trans('canvas::messages.delete_success', ['entity' => 'User']));
 
         return redirect()->route('canvas.admin.user.index');
     }

--- a/src/Jobs/BlogIndexData.php
+++ b/src/Jobs/BlogIndexData.php
@@ -61,7 +61,7 @@ class BlogIndexData
             ->orderBy('published_at', $reverse_direction ? 'asc' : 'desc')
             ->simplePaginate(config('blog.posts_per_page'));
 
-        $posts->addQuery('tag', $tag->tag);
+        $posts->appends('tag', $tag->tag);
 
         $page_image = $tag->page_image ?: config('blog.page_image');
 


### PR DESCRIPTION
This PR includes the changes necessary for the Laravel 5.4 upgrade.

3 changes are required:
- Change `Session::set` usage to instead be `Session::put`
- Change `$router->middleware(…` calls to new method name `$router->aliasMiddleware(…`
- Change Paginator `addQuery` call to `appends` instead; visibility of `addQuery` was made protected.